### PR TITLE
Gantt Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/.idea

--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ to make the learning experience more engaging.
 ### Diagram showing user interface of flash card section
 
 ![Flashcard Sketch.png](docs%2FFlashcard%20Sketch.png)
+
+# Crediting
+
+- [Update every minute clock used in GanttChart.jsx](https://stackoverflow.com/a/23450004)

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ to make the learning experience more engaging.
 
 ## Rough Sketches
 
-# Diagram of home page user interface of application
+### Diagram of home page user interface of application
 
 ![Dashboard Sketch.jpg](docs%2FDashboard%20Sketch.jpg)
 
-# Diagram showing user interface of flash card section
+### Diagram showing user interface of flash card section
 
 ![Flashcard Sketch.png](docs%2FFlashcard%20Sketch.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "d3": "^7.8.5",
         "react": "^18.2.0",
         "react-circular-progressbar": "^2.1.0",
         "react-datepicker": "^4.12.0",
@@ -6915,6 +6916,384 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/d3": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7047,6 +7426,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -9633,6 +10020,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -15880,6 +16275,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+    },
     "node_modules/rollup": {
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
@@ -15970,6 +16370,11 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/rxjs": {
       "version": "7.8.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "d3": "^7.8.5",
     "react": "^18.2.0",
     "react-circular-progressbar": "^2.1.0",
     "react-datepicker": "^4.12.0",

--- a/src/Styles/GanttChart.css
+++ b/src/Styles/GanttChart.css
@@ -1,0 +1,18 @@
+/* Tooltip */
+#gantt-chart-tooltip {
+  position: absolute;
+  display: none;
+  background: #fff;
+  box-shadow: 3px 3px 3px 0px rgb(92 92 92 / 0.5);
+  border: 1px solid #ddd;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 8px;
+  min-width: 160px;
+  color: #333;
+}
+.tooltip-title {
+  color: #000;
+  font-size: 14px;
+  font-weight: 600;
+}

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import * as d3 from "d3";
 
 const Days = {
@@ -11,8 +11,8 @@ const Days = {
     Saturday: Symbol("Saturday")
 }
 
-const GanttChart = () => {
-    const [data, setData] = useState([
+const GanttChart = (props) => {
+    const [data] = useState([
         {
             id: 1,
             userId: 1,
@@ -92,8 +92,140 @@ const GanttChart = () => {
             description: "Habit taking place 2 days in the future.",
             color: '#AD8886',
             percentCompletion: 0
+        },
+        {
+            id: 6,
+            userId: 1,
+            name: "Past Todo",
+            isRepeating: false,
+            daysOfTheWeek: null,
+            startTime: new Date(Date.now() - 180 * 60000),
+            endTime: new Date(Date.now() + 240 * 60000),
+            description: "One-time todo which took place 3 hours ago.",
+            color: '#A103FC',
+            percentCompletion: 75
+        },
+        {
+            id: 7,
+            userId: 1,
+            name: "Past Todo",
+            isRepeating: false,
+            daysOfTheWeek: null,
+            startTime: new Date(Date.now() - 180 * 60000),
+            endTime: new Date(Date.now() + 240 * 60000),
+            description: "One-time todo which took place 3 hours ago.",
+            color: '#A103FC',
+            percentCompletion: 75
+        },
+        {
+            id: 8,
+            userId: 1,
+            name: "Past Todo",
+            isRepeating: false,
+            daysOfTheWeek: null,
+            startTime: new Date(Date.now() - 180 * 60000),
+            endTime: new Date(Date.now() + 240 * 60000),
+            description: "One-time todo which took place 3 hours ago.",
+            color: '#A103FC',
+            percentCompletion: 75
         }
     ]);
+
+    useEffect(() => {
+        let vis = {};
+
+        // Create initial scales
+        vis.width = props.containerWidth - props.margin.left - props.margin.right;
+        vis.height = props.containerHeight - props.margin.top - props.margin.bottom;
+
+        // Create scales
+        vis.xScale = d3.scaleTime()
+            .range([0, vis.width]);
+
+        vis.yScale = d3.scaleBand()
+            .range([0, vis.height])
+            .paddingInner(0.8);
+
+        vis.xAxis = d3.axisTop(vis.xScale);
+
+        vis.yAxis = d3.axisLeft(vis.yScale)
+            .tickFormat(function(d) {
+                return d.substring(0, d.lastIndexOf("-"))
+            })
+            .tickSize(0);
+
+        vis.svg = d3.select(props.parentElement).append('svg')
+            .attr('width', props.containerWidth)
+            .attr('height', props.containerHeight);
+
+        vis.chart = vis.svg.append('g')
+            .attr('transform', `translate(${props.margin.left}, ${props.margin.top})`);
+
+        vis.xAxisG = vis.chart.append('g')
+            .attr('class', 'axis x-axis');
+
+        vis.yAxisG = vis.chart.append('g')
+            .attr('class', 'axis y-axis');
+
+        vis.xValue = d => d.startTime;
+        vis.yValue = d => d.name;
+
+        const xDomainStart = Date.now() - 12 * 60 * 60 * 1000;
+        const xDomainEnd = Date.now() + 12 * 60 * 60 * 1000;
+        const filteredData = data.filter(d => xDomainStart <= d.startTime && d.endTime <= xDomainEnd);
+        const formattedData = filteredData.map((d, i) => {
+           d.name = d.name +  '-' + i;
+           return d;
+        });
+        vis.xScale.domain([Date.now() - 12 * 60 * 60 * 1000, Date.now() + 12 * 60 * 60 * 1000])
+        vis.yScale.domain(formattedData.map(vis.yValue));
+
+        const xCoordNow = vis.xScale(Date.now()) + props.margin.left;
+        vis.svg.append("circle")
+            .attr("class", "circle")
+            .attr("cx", xCoordNow)
+            .attr("cy", props.margin.top)
+            .attr("r", 5)
+        vis.svg.append("line")
+            .attr("class", "line")
+            .attr("x1", xCoordNow)
+            .attr("y1", props.margin.top)
+            .attr("x2", xCoordNow)
+            .attr("y2", vis.height + props.margin.top)
+            .style("stroke-width", 2)
+            .style("stroke", "black")
+            .style("fill", "none");
+
+        d3.select(props.parentElement)
+            .style("overflow-y", "scroll")
+            .style("-webkit-overflow-scrolling", "touch");
+
+        let bars = vis.chart.selectAll('.bar')
+            .data(filteredData, d => d.id)
+            .join('rect');
+
+        bars.style('opacity', 0.5)
+            .style('opacity', 1)
+            .attr('class', 'bar')
+            .attr('x', d => vis.xScale(vis.xValue(d)))
+            .attr('width', d => {
+                const scaledWidth = vis.xScale(vis.xValue(d));
+                const x = vis.xScale(vis.xValue(d));
+                if (x + scaledWidth > vis.width) {
+                    return vis.width - x
+                }
+                return scaledWidth;
+            })
+            .attr('height', vis.yScale.bandwidth())
+            .attr('y', d => vis.yScale(vis.yValue(d)))
+            .attr('fill', d => d.color);
+
+        vis.xAxisG
+            .transition().duration(1000)
+            .call(vis.xAxis);
+
+        vis.yAxisG.call(vis.yAxis);
+    }, [data, props]);
 }
 
 export default GanttChart;

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -137,8 +137,23 @@ const GanttChart = (props) => {
     const Y_AXIS_G_ID = 'gantt-y-axis-g'
     const renderChart = useCallback(() => {
         // Chart dimension calculation
-        const width = props.containerWidth - props.margin.left - props.margin.right;
-        const height = props.containerHeight - props.margin.top - props.margin.bottom;
+        let containerWidth, containerHeight, margin;
+        if (props.containerWidth === undefined) {
+            containerWidth = 720;
+        }
+        if (props.containerHeight === undefined) {
+            containerHeight = 300;
+        }
+        if (props.margin === undefined) {
+            margin = {
+                top: 50,
+                right: 20,
+                bottom: 50,
+                left: 150
+            };
+        }
+        const width = containerWidth - margin.left - margin.right;
+        const height = containerHeight - margin.top - margin.bottom;
 
         // Create scales
         const xScale = d3.scaleTime()
@@ -161,12 +176,12 @@ const GanttChart = (props) => {
         if (svg.empty()) {
             svg = d3.select(props.parentElement).append('svg')
                 .attr('id', SVG_ID)
-                .attr('width', props.containerWidth)
-                .attr('height', props.containerHeight);
+                .attr('width', containerWidth)
+                .attr('height', containerHeight);
 
             chart = svg.append('g')
                 .attr('id', CHART_ID)
-                .attr('transform', `translate(${props.margin.left}, ${props.margin.top})`);
+                .attr('transform', `translate(${margin.left}, ${margin.top})`);
 
             xAxisG = chart.append('g')
                 .attr('id', X_AXIS_G_ID)
@@ -198,18 +213,18 @@ const GanttChart = (props) => {
 
         // RenderVis()
         // Add vertical line for current time
-        const xCoordNow = xScale(Date.now()) + props.margin.left;
+        const xCoordNow = xScale(Date.now()) + margin.left;
         svg.append("circle")
             .attr("class", "circle")
             .attr("cx", xCoordNow)
-            .attr("cy", props.margin.top)
+            .attr("cy", margin.top)
             .attr("r", 5)
         svg.append("line")
             .attr("class", "line")
             .attr("x1", xCoordNow)
-            .attr("y1", props.margin.top)
+            .attr("y1", margin.top)
             .attr("x2", xCoordNow)
-            .attr("y2", height + props.margin.top)
+            .attr("y2", height + margin.top)
             .style("stroke-width", 2)
             .style("stroke", "black")
             .style("fill", "none");

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -237,8 +237,7 @@ const GanttChart = (props) => {
             .attr('fill', d => d.color);
 
         // Call axes
-        xAxisG.transition().duration(1000)
-            .call(xAxis);
+        xAxisG.transition().call(xAxis);
         yAxisG.call(yAxis);
 
         // Reset data formatting
@@ -264,8 +263,7 @@ const GanttChart = (props) => {
         }, timeToNextTick);
     }
 
-    // Initial chart render and clock start
-    renderChart();
+    // Clock start
     runClock();
 }
 

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import * as d3 from "d3";
 
 const Days = {
@@ -131,101 +131,142 @@ const GanttChart = (props) => {
         }
     ]);
 
-    useEffect(() => {
-        let vis = {};
-
-        // Create initial scales
-        vis.width = props.containerWidth - props.margin.left - props.margin.right;
-        vis.height = props.containerHeight - props.margin.top - props.margin.bottom;
+    const SVG_ID = 'gantt-chart-svg';
+    const CHART_ID = 'gantt-chart-g';
+    const X_AXIS_G_ID = 'gantt-x-axis-g'
+    const Y_AXIS_G_ID = 'gantt-y-axis-g'
+    const renderChart = useCallback(() => {
+        // Chart dimension calculation
+        const width = props.containerWidth - props.margin.left - props.margin.right;
+        const height = props.containerHeight - props.margin.top - props.margin.bottom;
 
         // Create scales
-        vis.xScale = d3.scaleTime()
-            .range([0, vis.width]);
-
-        vis.yScale = d3.scaleBand()
-            .range([0, vis.height])
+        const xScale = d3.scaleTime()
+            .range([0, width]);
+        const yScale = d3.scaleBand()
+            .range([0, height])
             .paddingInner(0.8);
 
-        vis.xAxis = d3.axisTop(vis.xScale);
-
-        vis.yAxis = d3.axisLeft(vis.yScale)
+        // Create axes
+        const xAxis = d3.axisTop(xScale);
+        const yAxis = d3.axisLeft(yScale)
             .tickFormat(function(d) {
                 return d.substring(0, d.lastIndexOf("-"))
             })
             .tickSize(0);
 
-        vis.svg = d3.select(props.parentElement).append('svg')
-            .attr('width', props.containerWidth)
-            .attr('height', props.containerHeight);
+        // Chart group appending
+        let svg = d3.select('#' + SVG_ID);
+        let chart, xAxisG, yAxisG;
+        if (svg.empty()) {
+            svg = d3.select(props.parentElement).append('svg')
+                .attr('id', SVG_ID)
+                .attr('width', props.containerWidth)
+                .attr('height', props.containerHeight);
 
-        vis.chart = vis.svg.append('g')
-            .attr('transform', `translate(${props.margin.left}, ${props.margin.top})`);
+            chart = svg.append('g')
+                .attr('id', CHART_ID)
+                .attr('transform', `translate(${props.margin.left}, ${props.margin.top})`);
 
-        vis.xAxisG = vis.chart.append('g')
-            .attr('class', 'axis x-axis');
+            xAxisG = chart.append('g')
+                .attr('id', X_AXIS_G_ID)
+                .attr('class', 'axis x-axis');
 
-        vis.yAxisG = vis.chart.append('g')
-            .attr('class', 'axis y-axis');
+            yAxisG = chart.append('g')
+                .attr('id', Y_AXIS_G_ID)
+                .attr('class', 'axis y-axis');
+        } else {
+            chart = d3.select('#' + CHART_ID);
+            xAxisG = d3.select('#' + X_AXIS_G_ID);
+            yAxisG = d3.select('#' + Y_AXIS_G_ID);
+        }
 
-        vis.xValue = d => d.startTime;
-        vis.yValue = d => d.name;
+        // UpdateVis()
+        const xValue = d => d.startTime;
+        const yValue = d => d.name;
 
+        // Set domains and filter/format data
         const xDomainStart = Date.now() - 12 * 60 * 60 * 1000;
         const xDomainEnd = Date.now() + 12 * 60 * 60 * 1000;
         const filteredData = data.filter(d => xDomainStart <= d.startTime && d.endTime <= xDomainEnd);
         const formattedData = filteredData.map((d, i) => {
-           d.name = d.name +  '-' + i;
-           return d;
+            d.name = d.name +  '-' + i; // This allows for duplicate habit/to do names
+            return d;
         });
-        vis.xScale.domain([Date.now() - 12 * 60 * 60 * 1000, Date.now() + 12 * 60 * 60 * 1000])
-        vis.yScale.domain(formattedData.map(vis.yValue));
+        xScale.domain([Date.now() - 12 * 60 * 60 * 1000, Date.now() + 12 * 60 * 60 * 1000])
+        yScale.domain(formattedData.map(yValue));
 
-        const xCoordNow = vis.xScale(Date.now()) + props.margin.left;
-        vis.svg.append("circle")
+        // RenderVis()
+        // Add vertical line for current time
+        const xCoordNow = xScale(Date.now()) + props.margin.left;
+        svg.append("circle")
             .attr("class", "circle")
             .attr("cx", xCoordNow)
             .attr("cy", props.margin.top)
             .attr("r", 5)
-        vis.svg.append("line")
+        svg.append("line")
             .attr("class", "line")
             .attr("x1", xCoordNow)
             .attr("y1", props.margin.top)
             .attr("x2", xCoordNow)
-            .attr("y2", vis.height + props.margin.top)
+            .attr("y2", height + props.margin.top)
             .style("stroke-width", 2)
             .style("stroke", "black")
             .style("fill", "none");
 
-        d3.select(props.parentElement)
-            .style("overflow-y", "scroll")
-            .style("-webkit-overflow-scrolling", "touch");
-
-        let bars = vis.chart.selectAll('.bar')
+        // Add bars
+        let bars = chart.selectAll('.bar')
             .data(filteredData, d => d.id)
             .join('rect');
 
+        // Style bars
         bars.style('opacity', 0.5)
             .style('opacity', 1)
             .attr('class', 'bar')
-            .attr('x', d => vis.xScale(vis.xValue(d)))
+            .attr('x', d => xScale(xValue(d)))
             .attr('width', d => {
-                const scaledWidth = vis.xScale(vis.xValue(d));
-                const x = vis.xScale(vis.xValue(d));
-                if (x + scaledWidth > vis.width) {
-                    return vis.width - x
+                const scaledWidth = xScale(xValue(d));
+                const x = xScale(xValue(d));
+                if (x + scaledWidth > width) {
+                    return width - x
                 }
                 return scaledWidth;
             })
-            .attr('height', vis.yScale.bandwidth())
-            .attr('y', d => vis.yScale(vis.yValue(d)))
+            .attr('height', yScale.bandwidth())
+            .attr('y', d => yScale(yValue(d)))
             .attr('fill', d => d.color);
 
-        vis.xAxisG
-            .transition().duration(1000)
-            .call(vis.xAxis);
+        // Call axes
+        xAxisG.transition().duration(1000)
+            .call(xAxis);
+        yAxisG.call(yAxis);
 
-        vis.yAxisG.call(vis.yAxis);
+        // Reset data formatting
+        formattedData.map(d => {
+            d.name = d.name.substring(0, d.name.lastIndexOf("-"));
+            return d;
+        })
     }, [data, props]);
+
+    // Update the chart if data changes
+    useEffect(() => {
+        renderChart();
+    }, [data, props, renderChart]);
+
+    // Update the chart on every minute change (to keep 'now' line accurate)
+    // New instance of setTimeOut() every runClock() so no memory build-up due to garbage collector
+    const runClock = () => {
+        const now = new Date();
+        const timeToNextTick = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+        setTimeout(() => {
+           renderChart();
+           runClock();
+        }, timeToNextTick);
+    }
+
+    // Initial chart render and clock start
+    renderChart();
+    runClock();
 }
 
 export default GanttChart;

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -149,8 +149,8 @@ const GanttChart = (props) => {
             margin = {
                 top: 50,
                 right: 20,
-                bottom: 50,
-                left: 150
+                bottom: 25,
+                left: 100
             };
         }
         if (props.tooltipPadding === undefined) {
@@ -169,6 +169,7 @@ const GanttChart = (props) => {
 
         // Create axes
         const xAxis = d3.axisTop(xScale)
+            .tickSizeOuter(0);
         const yAxis = d3.axisLeft(yScale)
             .tickFormat(function(d) {
                 return d.substring(0, d.lastIndexOf("-"))
@@ -192,13 +193,11 @@ const GanttChart = (props) => {
                 .attr('id', X_AXIS_G_ID)
                 .attr('class', 'axis x-axis')
                 .style('font-size', 12)
-                .style('font-weight', 'bold');
 
             yAxisG = chart.append('g')
                 .attr('id', Y_AXIS_G_ID)
                 .attr('class', 'axis y-axis')
                 .style('font-size', 12)
-                .style('font-weight', 'bold');
         } else {
             chart = d3.select('#' + CHART_ID);
             xAxisG = d3.select('#' + X_AXIS_G_ID);
@@ -210,8 +209,8 @@ const GanttChart = (props) => {
         const yValue = d => d.name;
 
         // Set domains and filter/format data
-        const xDomainStart = Date.now() - 12 * 60 * 60 * 1000;
-        const xDomainEnd = Date.now() + 12 * 60 * 60 * 1000;
+        const xDomainStart = Date.now() - 1 * 60 * 60 * 1000;
+        const xDomainEnd = Date.now() + 1 * 60 * 60 * 1000;
         const filteredData = data.filter(d => xDomainStart <= d.endTime && d.startTime <= xDomainEnd);
         const formattedData = filteredData.map((d, i) => {
             d.name = d.name +  '-' + i; // This allows for duplicate habit/to do names
@@ -247,19 +246,27 @@ const GanttChart = (props) => {
         bars.style('opacity', 0.5)
             .style('opacity', 1)
             .attr('class', 'bar')
-            .attr('x', d => xScale(xValue(d)))
+            .attr('x', d => {
+                const x = xScale(xValue(d));
+                if (x < 0) {
+                    return 0
+                }
+                return x;
+            })
             .attr('width', d => {
                 const scaledWidth = xScale(d.endTime - d.startTime + xDomainStart);
-                const x = xScale(xValue(d));
-                if (x + scaledWidth > width) {
-                    return width - x
+                let x = xScale(xValue(d));
+                if (x < 0) {
+                    x = 0
+                }
+                if (x + scaledWidth > xScale(xDomainEnd)) {
+                    return xScale(xDomainEnd) - x;
                 }
                 return scaledWidth;
             })
             .attr('height', yScale.bandwidth())
             .attr('y', d => yScale(yValue(d)))
             .attr('fill', d => d.color)
-            .attr('rx', 8)
             .attr('stroke-width', 1)
             .attr('stroke', 'black');
 

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import * as d3 from "d3";
+import "../Styles/GanttChart.css"
 
 const Days = {
     Sunday: Symbol("Sunday"),
@@ -137,7 +138,7 @@ const GanttChart = (props) => {
     const Y_AXIS_G_ID = 'gantt-y-axis-g'
     const renderChart = useCallback(() => {
         // Chart dimension calculation
-        let containerWidth, containerHeight, margin;
+        let containerWidth, containerHeight, margin, tooltipPadding;
         if (props.containerWidth === undefined) {
             containerWidth = 720;
         }
@@ -151,6 +152,9 @@ const GanttChart = (props) => {
                 bottom: 50,
                 left: 150
             };
+        }
+        if (props.tooltipPadding === undefined) {
+            tooltipPadding = 15;
         }
         const width = containerWidth - margin.left - margin.right;
         const height = containerHeight - margin.top - margin.bottom;
@@ -251,6 +255,27 @@ const GanttChart = (props) => {
             .attr('y', d => yScale(yValue(d)))
             .attr('fill', d => d.color);
 
+        // Tooltip event listeners
+        bars.on('mouseover', (event,d) => {
+                d3.select('#gantt-chart-tooltip')
+                    .style('display', 'block')
+                    .style('left', (event.pageX + tooltipPadding) + 'px')
+                    .style('top', (event.pageY + tooltipPadding) + 'px')
+                    .html(`
+              <div class="tooltip-title">${d.name}</div>
+              <div><i>Completion: ${d.percentCompletion}%</i></div>
+              <div>${d.description}</div>
+            `);
+            })
+            .on('mousemove', (event) => {
+                d3.select('#gantt-chart-tooltip')
+                    .style('left', (event.pageX + tooltipPadding) + 'px')
+                    .style('top', (event.pageY + tooltipPadding) + 'px')
+            })
+            .on('mouseleave', () => {
+                d3.select('#gantt-chart-tooltip').style('display', 'none');
+            });
+
         // Call axes
         xAxisG.transition().call(xAxis);
         yAxisG.call(yAxis);
@@ -280,6 +305,8 @@ const GanttChart = (props) => {
 
     // Clock start
     runClock();
+
+    return <div id="gantt-chart-tooltip"></div>
 }
 
 export default GanttChart;

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -58,14 +58,14 @@ const GanttChart = (props) => {
             daysOfTheWeek: null,
             startTime: (function() {
                 const date = new Date();
-                date.setDate(date.getDate() - 2);
-                date.setHours(date.getHours() - 5);
+                date.setDate(date.getDate() - 1);
+                date.setHours(date.getHours() + 2);
                 return date;
             })(),
             endTime: (function() {
                 const date = new Date();
-                date.setDate(date.getDate() - 2);
-                date.setHours(date.getHours() - 3);
+                date.setDate(date.getDate() - 1);
+                date.setHours(date.getHours() + 5);
                 return date;
             })(),
             description: "Habit that took place 2 days in the past.",
@@ -80,13 +80,13 @@ const GanttChart = (props) => {
             daysOfTheWeek: null,
             startTime: (function() {
                 const date = new Date();
-                date.setDate(date.getDate() + 2);
+                date.setDate(date.getDate() + 1);
                 date.setHours(date.getHours() - 5);
                 return date;
             })(),
             endTime: (function() {
                 const date = new Date();
-                date.setDate(date.getDate() + 2);
+                date.setDate(date.getDate() + 1);
                 date.setHours(date.getHours() - 3);
                 return date;
             })(),
@@ -215,7 +215,7 @@ const GanttChart = (props) => {
         const formattedData = filteredData.map((d, i) => {
             d.name = d.name +  '-' + i; // This allows for duplicate habit/to do names
             return d;
-        });
+        }).sort((a, b) => a.startTime - b.startTime);
         xScale.domain([xDomainStart, xDomainEnd])
         yScale.domain(formattedData.map(yValue));
 

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from "react";
+import * as d3 from "d3";
+
+const Days = {
+    Sunday: Symbol("Sunday"),
+    Monday: Symbol("Monday"),
+    Tuesday: Symbol("Tuesday"),
+    Wednesday: Symbol("Wednesday"),
+    Thursday: Symbol("Thursday"),
+    Friday: Symbol("Friday"),
+    Saturday: Symbol("Saturday")
+}
+
+const GanttChart = () => {
+    const [data, setData] = useState([
+        {
+            id: 1,
+            userId: 1,
+            name: "Current Habit",
+            isRepeating: true,
+            daysOfTheWeek: new Set([Days.Monday, Days.Wednesday, Days.Friday]),
+            startTime: new Date(Date.now()),
+            endTime: new Date(Date.now() + 60 * 60000),
+            description: "Habit taking place right now for 1 hour; repeats MWF.",
+            color: '#03FCA5',
+            percentCompletion: 75
+        },
+        {
+            id: 2,
+            userId: 1,
+            name: "Past Todo",
+            isRepeating: false,
+            daysOfTheWeek: null,
+            startTime: new Date(Date.now() - 180 * 60000),
+            endTime: new Date(Date.now() + 240 * 60000),
+            description: "One-time todo which took place 3 hours ago.",
+            color: '#A103FC',
+            percentCompletion: 75
+        },
+        {
+            id: 3,
+            userId: 1,
+            name: "Future Todo",
+            isRepeating: true,
+            daysOfTheWeek: new Set([Days.Monday, Days.Wednesday, Days.Friday]),
+            startTime: new Date(Date.now() + 120 * 60000),
+            endTime: new Date(Date.now() + 180 * 60000),
+            description: "Todo taking place in 2 hours; repeats MWF.",
+            color: '#F403FC',
+            percentCompletion: 75
+        },
+        {
+            id: 4,
+            userId: 1,
+            name: "Past Habit",
+            isRepeating: false,
+            daysOfTheWeek: null,
+            startTime: (function() {
+                const date = new Date();
+                date.setDate(date.getDate() - 2);
+                date.setHours(date.getHours() - 5);
+                return date;
+            })(),
+            endTime: (function() {
+                const date = new Date();
+                date.setDate(date.getDate() - 2);
+                date.setHours(date.getHours() - 3);
+                return date;
+            })(),
+            description: "Habit that took place 2 days in the past.",
+            color: '#03DBFC',
+            percentCompletion: 100
+        },
+        {
+            id: 5,
+            userId: 1,
+            name: "Far Future Habit",
+            isRepeating: false,
+            daysOfTheWeek: null,
+            startTime: (function() {
+                const date = new Date();
+                date.setDate(date.getDate() + 2);
+                date.setHours(date.getHours() - 5);
+                return date;
+            })(),
+            endTime: (function() {
+                const date = new Date();
+                date.setDate(date.getDate() + 2);
+                date.setHours(date.getHours() - 3);
+                return date;
+            })(),
+            description: "Habit taking place 2 days in the future.",
+            color: '#AD8886',
+            percentCompletion: 0
+        }
+    ]);
+}
+
+export default GanttChart;

--- a/src/components/GanttChart/GanttChart.jsx
+++ b/src/components/GanttChart/GanttChart.jsx
@@ -34,7 +34,7 @@ const GanttChart = (props) => {
             daysOfTheWeek: null,
             startTime: new Date(Date.now() - 180 * 60000),
             endTime: new Date(Date.now() + 240 * 60000),
-            description: "One-time todo which took place 3 hours ago.",
+            description: "One-time todo which started 3 hours ago.",
             color: '#A103FC',
             percentCompletion: 75
         },
@@ -68,7 +68,7 @@ const GanttChart = (props) => {
                 date.setHours(date.getHours() + 5);
                 return date;
             })(),
-            description: "Habit that took place 2 days in the past.",
+            description: "Habit that took place 1 day in the past.",
             color: '#03DBFC',
             percentCompletion: 100
         },
@@ -90,7 +90,7 @@ const GanttChart = (props) => {
                 date.setHours(date.getHours() - 3);
                 return date;
             })(),
-            description: "Habit taking place 2 days in the future.",
+            description: "Habit taking place 1 day in the future.",
             color: '#AD8886',
             percentCompletion: 0
         },
@@ -102,7 +102,7 @@ const GanttChart = (props) => {
             daysOfTheWeek: null,
             startTime: new Date(Date.now() - 180 * 60000),
             endTime: new Date(Date.now() + 240 * 60000),
-            description: "One-time todo which took place 3 hours ago.",
+            description: "One-time todo which started 3 hours ago.",
             color: '#A103FC',
             percentCompletion: 75
         },
@@ -114,7 +114,7 @@ const GanttChart = (props) => {
             daysOfTheWeek: null,
             startTime: new Date(Date.now() - 180 * 60000),
             endTime: new Date(Date.now() + 240 * 60000),
-            description: "One-time todo which took place 3 hours ago.",
+            description: "One-time todo which started 3 hours ago.",
             color: '#A103FC',
             percentCompletion: 75
         },
@@ -126,7 +126,7 @@ const GanttChart = (props) => {
             daysOfTheWeek: null,
             startTime: new Date(Date.now() - 180 * 60000),
             endTime: new Date(Date.now() + 240 * 60000),
-            description: "One-time todo which took place 3 hours ago.",
+            description: "One-time todo which started 3 hours ago.",
             color: '#A103FC',
             percentCompletion: 75
         }
@@ -147,10 +147,10 @@ const GanttChart = (props) => {
         }
         if (props.margin === undefined) {
             margin = {
-                top: 50,
+                top: 35,
                 right: 20,
                 bottom: 25,
-                left: 100
+                left: 110
             };
         }
         if (props.tooltipPadding === undefined) {
@@ -220,14 +220,20 @@ const GanttChart = (props) => {
         yScale.domain(formattedData.map(yValue));
 
         // RenderVis()
-        // Add vertical line for current time
+        // Add/update vertical line for current time
         const xCoordNow = xScale(Date.now()) + margin.left;
+        const CIRCLE_ID = "now-circle";
+        const LINE_ID = "now-line";
+        d3.select('#' + CIRCLE_ID).remove();
+        d3.select('#' + LINE_ID).remove();
         svg.append("circle")
+            .attr("id", CIRCLE_ID)
             .attr("class", "circle")
             .attr("cx", xCoordNow)
             .attr("cy", margin.top)
             .attr("r", 5)
         svg.append("line")
+            .attr("id", LINE_ID)
             .attr("class", "line")
             .attr("x1", xCoordNow)
             .attr("y1", margin.top)

--- a/src/components/GanttChart/GanttChart.jsx
+++ b/src/components/GanttChart/GanttChart.jsx
@@ -209,8 +209,8 @@ const GanttChart = (props) => {
         const yValue = d => d.name;
 
         // Set domains and filter/format data
-        const xDomainStart = Date.now() - 8 * 60 * 60 * 1000;
-        const xDomainEnd = Date.now() + 8 * 60 * 60 * 1000;
+        const xDomainStart = Date.now() - 24 * 60 * 60 * 1000;
+        const xDomainEnd = Date.now() + 24 * 60 * 60 * 1000;
         const filteredData = data.filter(d => xDomainStart <= d.endTime && d.startTime <= xDomainEnd);
         const formattedData = filteredData.map((d, i) => {
             d.name = d.name +  '-' + i; // This allows for duplicate habit/to do names

--- a/src/components/GanttChart/GanttChart.jsx
+++ b/src/components/GanttChart/GanttChart.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import * as d3 from "d3";
-import "../Styles/GanttChart.css"
+import "../../Styles/GanttChart.css"
 
 const Days = {
     Sunday: Symbol("Sunday"),
@@ -180,7 +180,7 @@ const GanttChart = (props) => {
         let svg = d3.select('#' + SVG_ID);
         let chart, xAxisG, yAxisG;
         if (svg.empty()) {
-            svg = d3.select(props.parentElement).append('svg')
+            svg = d3.select('.gantt-chart').append('svg')
                 .attr('id', SVG_ID)
                 .attr('width', containerWidth)
                 .attr('height', containerHeight);
@@ -209,8 +209,8 @@ const GanttChart = (props) => {
         const yValue = d => d.name;
 
         // Set domains and filter/format data
-        const xDomainStart = Date.now() - 1 * 60 * 60 * 1000;
-        const xDomainEnd = Date.now() + 1 * 60 * 60 * 1000;
+        const xDomainStart = Date.now() - 8 * 60 * 60 * 1000;
+        const xDomainEnd = Date.now() + 8 * 60 * 60 * 1000;
         const filteredData = data.filter(d => xDomainStart <= d.endTime && d.startTime <= xDomainEnd);
         const formattedData = filteredData.map((d, i) => {
             d.name = d.name +  '-' + i; // This allows for duplicate habit/to do names
@@ -294,7 +294,7 @@ const GanttChart = (props) => {
             });
 
         // Call axes
-        xAxisG.transition().call(xAxis);
+        xAxisG.call(xAxis);
         yAxisG.call(yAxis);
 
         // Reset data formatting

--- a/src/components/GanttChart/GanttChartContainer.jsx
+++ b/src/components/GanttChart/GanttChartContainer.jsx
@@ -1,9 +1,13 @@
 import GanttChart from "./GanttChart";
 
 const GanttChartContainer = () => {
-    return <div className='gantt-chart'>
-        <GanttChart />
-    </div>
+    return (
+        <div className='bg-clip-border rounded-xl bg-white shadow-lg'>
+            <div className='gantt-chart'>
+                <GanttChart />
+            </div>
+        </div>
+    );
 }
 
 export default GanttChartContainer;

--- a/src/components/GanttChart/GanttChartContainer.jsx
+++ b/src/components/GanttChart/GanttChartContainer.jsx
@@ -3,6 +3,7 @@ import GanttChart from "./GanttChart";
 const GanttChartContainer = () => {
     return (
         <div className='bg-clip-border rounded-xl bg-white shadow-lg'>
+            <h1 className='ml-10 mt-3 text-5xl font-bold leading-none tracking-tight dark:text-white'>Gantt Chart</h1>
             <div className='gantt-chart'>
                 <GanttChart />
             </div>

--- a/src/components/GanttChart/GanttChartContainer.jsx
+++ b/src/components/GanttChart/GanttChartContainer.jsx
@@ -1,0 +1,9 @@
+import GanttChart from "./GanttChart";
+
+const GanttChartContainer = () => {
+    return <div className='gantt-chart'>
+        <GanttChart />
+    </div>
+}
+
+export default GanttChartContainer;

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,6 +1,7 @@
 import HabitsView from "../components/Habits/HabitsView";
 import TODOListMainView from "../components/TODOList/TODOListMainView";
 import Pomodoro from "../components/Timer/Pomodoro";
+import GanttChart from "../components/GanttChart";
 
 const DashboardPage = () => {
   return (
@@ -13,6 +14,9 @@ const DashboardPage = () => {
       </div>
       <div>
         <HabitsView />
+      </div>
+      <div>
+        <GanttChart />
       </div>
     </div>
   );

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -15,8 +15,19 @@ const DashboardPage = () => {
       <div>
         <HabitsView />
       </div>
-      <div>
-        <GanttChart />
+      <div className="gantt-chart">
+        <GanttChart
+          parentElement=".gantt-chart"
+          containerWidth={720}
+          containerHeight={300}
+          margin={{
+            top: 50,
+            right: 20,
+            bottom: 50,
+            left: 150,
+          }}
+          tooltipPadding={15}
+        />
       </div>
     </div>
   );

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -16,18 +16,7 @@ const DashboardPage = () => {
         <HabitsView />
       </div>
       <div className="gantt-chart">
-        <GanttChart
-          parentElement=".gantt-chart"
-          containerWidth={720}
-          containerHeight={300}
-          margin={{
-            top: 50,
-            right: 20,
-            bottom: 50,
-            left: 150,
-          }}
-          tooltipPadding={15}
-        />
+        <GanttChart parentElement=".gantt-chart" />
       </div>
     </div>
   );

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -1,7 +1,7 @@
 import HabitsView from "../components/Habits/HabitsView";
 import TODOListMainView from "../components/TODOList/TODOListMainView";
 import Pomodoro from "../components/Timer/Pomodoro";
-import GanttChart from "../components/GanttChart";
+import GanttChartContainer from "../components/GanttChart/GanttChartContainer";
 
 const DashboardPage = () => {
   return (
@@ -15,9 +15,7 @@ const DashboardPage = () => {
       <div>
         <HabitsView />
       </div>
-      <div className="gantt-chart">
-        <GanttChart parentElement=".gantt-chart" />
-      </div>
+      <GanttChartContainer />
     </div>
   );
 };


### PR DESCRIPTION
I tried to separate the d3 code into three functions as was taught in 447 but due to problems regarding dependencies within useEffect and persisting changes past every run of useEffect I ended up putting everything into one useEffect.

I'm using some dummy data just to replicate the types of todos and habits we might have eventually.

I also tried putting a range slider to adjust the axis range before and after the line but unfortunately material tailwind doesn't have the material range slider.

I'm not the best at styling so let me know if something could be changed.

Potential future enhancements/things I tried:
1. Vertical scrolling/brushing
2. Changeable axis range
3. Add and remove habits from chart
4. Default chart display settings on a per user basis

![image](https://github.com/awctw/study-dash/assets/56493743/cb62cd05-955f-44ac-b530-755802eddd17)
