### PR TITLE
warning fixed

### DIFF
--- a/client/src/components/flashcard/flashcardModal.jsx
+++ b/client/src/components/flashcard/flashcardModal.jsx
@@ -86,6 +86,8 @@ const FlashCardModal = (props) => {
           className="w-3/4 rounded-lg ml-2 items-center shadow-none"
           key={key}
         >
+          {/* needs at least 1 child */}
+          <></>
           {id && <Cards moduleId={id} reset={handleReset} />}
         </Card>
       </Dialog>


### PR DESCRIPTION
Warning: Failed prop type: The prop `children` is marked as required in `MaterialTailwind.Card` should now be fixed.