### PR TITLE
Add color to Category

### DIFF
--- a/server/models/Category.model.js
+++ b/server/models/Category.model.js
@@ -11,6 +11,10 @@ const categorySchema = new mongoose.Schema({
     type: String,
     required: true,
     trim: true,
+  },
+  color: {
+    type: String,
+    default: '#000000'
   }
 });
 


### PR DESCRIPTION
![image](https://github.com/awctw/study-dash/assets/56493743/e360d219-28ae-4494-b2c6-68380c5449e3)


@HeinzUBC this is the only change that I'm suggesting: it would involve no change on your side. This would eliminate a lot of code smell associated with ChartSettings controller which currently needs code to sync up the list of colors with which category they belong to and which user they belong to.

@AlanZhangDev could also use this as well and add a reference to a category to habits (so habits have color on the Gantt Chart). Whether or not he wants to do this before or after the 29th is up to him.