### PR TITLE
Progress 5 chart improvements

### DIFF
--- a/client/src/components/GanttChart/ChartSettingsModal.jsx
+++ b/client/src/components/GanttChart/ChartSettingsModal.jsx
@@ -9,6 +9,7 @@ import {
 import React, {useEffect, useState} from "react";
 import {useDispatch, useSelector} from "react-redux";
 import { putChartSettingsAsync } from "../../store/chartSettings/thunks";
+import {Player} from "@lottiefiles/react-lottie-player";
 
 const ChartSettingsModal = (props) => {
     const user = useSelector((state) => state.loginReducer);
@@ -41,36 +42,82 @@ const ChartSettingsModal = (props) => {
                         label="Visible Hour Range (1 to 84 Hours Before and After)"
                         color="blue-gray"
                         type="number"
-                        value={modalChartSettings.axisScale}
+                        containerProps={{ className: "mb-5" }}
+                        value={modalChartSettings.axisTimeScale}
                         onChange={(e) => {
                             // Max and min checking
                             if (e.target.value > 84) {
                                 e.target.value = "84";
                                 setModalChartSettings((prevProps) => ({
                                     ...prevProps,
-                                    axisScale: 84
+                                    axisTimeScale: 84
                                 }))
                             } else if (e.target.value < 1) {
                                 e.target.value = "1";
                                 setModalChartSettings((prevProps) => ({
                                     ...prevProps,
-                                    axisScale: 1
+                                    axisTimeScale: 1
                                 }))
                             }
 
-                            // Set axisScale
+                            // Set axisTimeScale
                             setModalChartSettings((prevProps) => ({
                                 ...prevProps,
-                                axisScale: e.target.value
+                                axisTimeScale: e.target.value
                             }))
                         }}
                     />
-                    <Typography variant="h6" color="blue-gray" className="mt-3 mb-5">
+                    <Input
+                        variant="outlined"
+                        label="Relative Vertical Scale (1 to 100)"
+                        color="blue-gray"
+                        type="number"
+                        value={modalChartSettings.axisVerticalScale}
+                        onChange={(e) => {
+                            // Max and min checking
+                            if (e.target.value > 100) {
+                                e.target.value = "100";
+                                setModalChartSettings((prevProps) => ({
+                                    ...prevProps,
+                                    axisVerticalScale: 100
+                                }))
+                            } else if (e.target.value < 1) {
+                                e.target.value = "1";
+                                setModalChartSettings((prevProps) => ({
+                                    ...prevProps,
+                                    axisVerticalScale: 1
+                                }))
+                            }
+
+                            // Set axisTimeScale
+                            setModalChartSettings((prevProps) => ({
+                                ...prevProps,
+                                axisVerticalScale: e.target.value
+                            }))
+                        }}
+                    />
+                    <Typography variant="h6" color="blue-gray" className="mt-3 text-center">
                         Category Colors
                     </Typography>
+                    {modalChartSettings.categoryColors.length === 0 ?
+                        <div className="mx-auto">
+                            <Typography className="text-center">
+                                No categories to color...
+                            </Typography>
+                            <div className="flex items-center justify-center">
+                                <Player
+                                    src={
+                                        "https://lottie.host/13926b54-ea64-4465-bbe6-2fc45507cb74/jiSPjnMiBV.json"
+                                    }
+                                    style={{ height: "300px", width: "600px", padding: 0 }}
+                                    autoplay
+                                    loop
+                                />
+                            </div>
+                        </div> : null}
                     <div className="grid gap-x-3 gap-y-5 sm:grid-cols-3">
                         {modalChartSettings.categoryColors.map((item, index) =>
-                            <div key={index} className="sm:col-span-1">
+                            <div key={index} className="sm:col-span-1 mt-5">
                                 <Input
                                     type="color"
                                     className="mb-5"
@@ -79,7 +126,8 @@ const ChartSettingsModal = (props) => {
                                     color="blue-gray"
                                     value={item.color}
                                     onChange={(e) => setModalChartSettings((prevState) => ({
-                                        axisScale: prevState.axisScale,
+                                        axisTimeScale: prevState.axisTimeScale,
+                                        axisVerticalScale: prevState.axisVerticalScale,
                                         categoryColors: prevState.categoryColors.map(c => {
                                             if (c.category === item.category) {
                                                 c.color = e.target.value;
@@ -104,12 +152,6 @@ const ChartSettingsModal = (props) => {
                     <Button
                         className="bg-indigo-300 text-white m-2"
                         onClick={() => {
-                            if (modalChartSettings.axisScale.length <= 0) return;
-                            for (let i = 0; i < modalChartSettings.categoryColors.length; i++) {
-                                if (modalChartSettings.categoryColors[i].length <= 0) {
-                                    return;
-                                }
-                            }
                             handlePut();
                             props.setVisible(false);
                         }}

--- a/client/src/components/GanttChart/ChartSettingsModal.jsx
+++ b/client/src/components/GanttChart/ChartSettingsModal.jsx
@@ -38,14 +38,32 @@ const ChartSettingsModal = (props) => {
                     </Typography>
                     <Input
                         variant="outlined"
-                        label="Visible Hour Range (Before and After)"
+                        label="Visible Hour Range (1 to 84 Hours Before and After)"
                         color="blue-gray"
                         type="number"
                         value={modalChartSettings.axisScale}
-                        onChange={(e) => setModalChartSettings((prevProps) => ({
-                            ...prevProps,
-                            axisScale: e.target.value
-                        }))}
+                        onChange={(e) => {
+                            // Max and min checking
+                            if (e.target.value > 84) {
+                                e.target.value = "84";
+                                setModalChartSettings((prevProps) => ({
+                                    ...prevProps,
+                                    axisScale: 84
+                                }))
+                            } else if (e.target.value < 1) {
+                                e.target.value = "1";
+                                setModalChartSettings((prevProps) => ({
+                                    ...prevProps,
+                                    axisScale: 1
+                                }))
+                            }
+
+                            // Set axisScale
+                            setModalChartSettings((prevProps) => ({
+                                ...prevProps,
+                                axisScale: e.target.value
+                            }))
+                        }}
                     />
                     <Typography variant="h6" color="blue-gray" className="mt-3 mb-5">
                         Category Colors

--- a/client/src/components/GanttChart/GanttChart.jsx
+++ b/client/src/components/GanttChart/GanttChart.jsx
@@ -38,8 +38,8 @@ const GanttChart = (props) => {
     const CIRCLE_RADIUS = 5;
     const renderChart = useCallback(() => {
         // Filter data to see if the chart needs to be rendered
-        const xDomainStart = Date.now() - upToDateChartSettings.current.axisScale * 60 * 60 * 1000;
-        const xDomainEnd = Date.now() + upToDateChartSettings.current.axisScale * 60 * 60 * 1000;
+        const xDomainStart = Date.now() - upToDateChartSettings.current.axisTimeScale * 60 * 60 * 1000;
+        const xDomainEnd = Date.now() + upToDateChartSettings.current.axisTimeScale * 60 * 60 * 1000;
         // 'Clone' upToDateTodos.current to bypass read-only for scaleBand duplicate title handling
         let filteredData = JSON.parse(JSON.stringify(upToDateTodos.current));
         filteredData = filteredData.filter(d => Date.parse(d.endDate) - Date.parse(d.startDate) !== 0 &&
@@ -109,8 +109,8 @@ const GanttChart = (props) => {
         }
         // Increasing containerHeight affects inner chart height
         if (props.containerHeight === undefined) {
-            // 40 px per item
-            containerHeight = margin.top + margin.bottom + 30 * filteredData.length;
+            // Variable px per item
+            containerHeight = margin.top + margin.bottom + upToDateChartSettings.current.axisVerticalScale * filteredData.length;
         }
         if (props.tooltipPadding === undefined) {
             tooltipPadding = 15;

--- a/client/src/components/GanttChart/GanttChart.jsx
+++ b/client/src/components/GanttChart/GanttChart.jsx
@@ -40,8 +40,8 @@ const GanttChart = (props) => {
         const xDomainEnd = Date.now() + upToDateChartSettings.current.axisScale * 60 * 60 * 1000;
         // 'Clone' upToDateTodos.current to bypass read-only for scaleBand duplicate title handling
         let filteredData = JSON.parse(JSON.stringify(upToDateTodos.current));
-        filteredData = filteredData.filter(d => xDomainStart <= Date.parse(d.endDate) &&
-            Date.parse(d.startDate) <= xDomainEnd);
+        filteredData = filteredData.filter(d => Date.parse(d.endDate) - Date.parse(d.startDate) !== 0 &&
+            xDomainStart <= Date.parse(d.endDate) && Date.parse(d.startDate) <= xDomainEnd);
 
         // Habit day of the week handling
         let currDate = new Date(xDomainStart);
@@ -61,7 +61,7 @@ const GanttChart = (props) => {
                             retDate = new Date(retDate).setFullYear(currDate.getFullYear());
                             return retDate;
                         }();
-                        if (xDomainStart <= endDate && startDate <= xDomainEnd) {
+                        if (endDate - startDate !== 0 && xDomainStart <= endDate && startDate <= xDomainEnd) {
                             filteredData.push({
                                 _id: habit["_id"],
                                 title: habit.name,

--- a/server/controllers/chartSettings.controller.js
+++ b/server/controllers/chartSettings.controller.js
@@ -21,7 +21,10 @@ const getChartSettings = async (req, res, next) => {
             await chartSettings.save()
             res.status(200).send(chartSettings);
         } else {
-            for (const category of await Category.find({userID: req.params.userID})) {
+            const userCategories = await Category.find({userID: req.params.userID});
+
+            // Union arrays
+            for (const category of userCategories) {
                 if (result.categoryColors.find(c => c.categoryID === category["_id"].toString()) === undefined) {
                     result.categoryColors.push({
                         categoryID: category["_id"],
@@ -30,6 +33,14 @@ const getChartSettings = async (req, res, next) => {
                     });
                 }
             }
+            let idsToRemove = [];
+            for (const category of result.categoryColors) {
+                if (userCategories.find(c => c["_id"].toString() === category.categoryID) === undefined) {
+                    idsToRemove.push(category.categoryID);
+                }
+            }
+            result.categoryColors = result.categoryColors.filter(c => !idsToRemove.includes(c.categoryID));
+
             await result.save();
             res.status(200).send(result);
         }

--- a/server/controllers/chartSettings.controller.js
+++ b/server/controllers/chartSettings.controller.js
@@ -15,7 +15,8 @@ const getChartSettings = async (req, res, next) => {
             }
             const chartSettings = new ChartSettings({
                 userID: req.params.userID,
-                axisScale: 24,
+                axisTimeScale: 24,
+                axisVerticalScale: 30,
                 categoryColors: categoryColors
             });
             await chartSettings.save()
@@ -56,7 +57,8 @@ const putChartSettings = async (req, res, next) => {
         .then((result) => {
             res.status(200).send({
                 userID: req.params.userID,
-                axisScale: result.axisScale,
+                axisTimeScale: result.axisTimeScale,
+                axisVerticalScale: result.axisVerticalScale,
                 categoryColors: result.categoryColors
             });
         })

--- a/server/models/chartSettings.model.js
+++ b/server/models/chartSettings.model.js
@@ -4,10 +4,15 @@ const ChartSettings = mongoose.model(
     "ChartSettings",
     new mongoose.Schema({
         userID: String,
-        axisScale: {
+        axisTimeScale: {
             type: Number,
             min: 1,
             max: 84
+        },
+        axisVerticalScale: {
+            type: Number,
+            min: 1,
+            max: 100
         },
         categoryColors: [{ categoryID: String, category: String, color: String}]
     })

--- a/server/models/chartSettings.model.js
+++ b/server/models/chartSettings.model.js
@@ -4,7 +4,11 @@ const ChartSettings = mongoose.model(
     "ChartSettings",
     new mongoose.Schema({
         userID: String,
-        axisScale: Number,
+        axisScale: {
+            type: Number,
+            min: 1,
+            max: 84
+        },
         categoryColors: [{ categoryID: String, category: String, color: String}]
     })
 );


### PR DESCRIPTION
- Added min and max values to chart time scale since massive time scale can lag the application if there are many repeated habits to display
- Stopped habits and TODOs with a duration of zero from appearing on the Gantt Chart
- Fixed bug where deleted categories remained in ChartSettings
- Hopefully fixed bug where Gantt Chart would flicker empty or back to old data (please let me know if you are still encountering this issue!)
- Added option for Gantt Chart's vertical axis scale to be changed (current allowed values go from 1 to 100 but the minimum of 1 is impractical and more so to allow people to input values even with the forced input validation that I'm using since min and max props in input do not stop users from typing in a value beyond the allowed range: if anyone has a better way to accomplish this please let me know!)
- Added sleeping dog animation to chart modal if no categories exist