### PR TITLE
Suppress extraneous messages when starting DB

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -3,6 +3,8 @@ mongoose.Promise = global.Promise;
 
 const db = {};
 
+mongoose.set('strictQuery', true);
+
 db.mongoose = mongoose;
 
 db.user = require("./user.model");


### PR DESCRIPTION
Now, when you launch the backend, in the terminal there will no longer be extraneous warning messages. Cleans up the terminal view