### PR TITLE
Fix habit date bug and only display today's habits

### DIFF
--- a/client/src/components/Habits/HabitsView.js
+++ b/client/src/components/Habits/HabitsView.js
@@ -26,6 +26,8 @@ import {
   deleteHabitAsync,
 } from "../../store/habits/thunks";
 import dayjs from "dayjs";
+let utc = require('dayjs/plugin/utc')
+dayjs.extend(utc)
 
 const HabitsView = () => {
   /* Adapted From Material UI Docs */
@@ -97,8 +99,8 @@ const HabitsView = () => {
     let day = date.getDate();
     let month = date.getMonth();
     let year = date.getFullYear();
-    date = new Date(year, month, day);
-    let today = dayjs(date);
+    date = Date.UTC(year, month, day);
+    let today = dayjs(date).utc();
 
     return !(
       habit.dates.length === 0 ||

--- a/client/src/components/Habits/HabitsView.js
+++ b/client/src/components/Habits/HabitsView.js
@@ -95,16 +95,6 @@ const HabitsView = () => {
   };
 
   const isTicked = (habit) => {
-    // let date = new Date();
-    // let date = dayjs().utc();
-    // let day = date.getDate();
-    // let month = date.getMonth();
-    // let year = date.getFullYear();
-    // let day = date.get("date")
-    // let month = date.get("month")
-    // let year = date.get("year")
-    // date = Date.UTC(year, month, day);
-    // let today = dayjs(date).utc();
     let today = dayjs().utc();
 
     return !(
@@ -122,7 +112,7 @@ const HabitsView = () => {
             Habits
           </Typography>
           <Typography className="mb-3">
-            Here's an overview of all your Habits.
+            Here's your habits for today.
           </Typography>
         </div>
         <CardBody className="flex-1 py-0 max-h-[10rem] overflow-y-auto scrollbar-none scrollbar-thumb-rounded-full scrollbar-thumb-blue-gray-100/50">

--- a/client/src/components/Habits/HabitsView.js
+++ b/client/src/components/Habits/HabitsView.js
@@ -95,10 +95,14 @@ const HabitsView = () => {
   };
 
   const isTicked = (habit) => {
-    let date = new Date();
-    let day = date.getDate();
-    let month = date.getMonth();
-    let year = date.getFullYear();
+    // let date = new Date();
+    let date = dayjs().utc();
+    // let day = date.getDate();
+    // let month = date.getMonth();
+    // let year = date.getFullYear();
+    let day = date.get("date")
+    let month = date.get("month")
+    let year = date.get("year")
     date = Date.UTC(year, month, day);
     let today = dayjs(date).utc();
 

--- a/client/src/components/Habits/HabitsView.js
+++ b/client/src/components/Habits/HabitsView.js
@@ -96,20 +96,21 @@ const HabitsView = () => {
 
   const isTicked = (habit) => {
     // let date = new Date();
-    let date = dayjs().utc();
+    // let date = dayjs().utc();
     // let day = date.getDate();
     // let month = date.getMonth();
     // let year = date.getFullYear();
-    let day = date.get("date")
-    let month = date.get("month")
-    let year = date.get("year")
-    date = Date.UTC(year, month, day);
-    let today = dayjs(date).utc();
+    // let day = date.get("date")
+    // let month = date.get("month")
+    // let year = date.get("year")
+    // date = Date.UTC(year, month, day);
+    // let today = dayjs(date).utc();
+    let today = dayjs().utc();
 
     return !(
       habit.dates.length === 0 ||
       (habit.dates.length > 0 &&
-        today.diff(habit.dates[habit.dates.length - 1]))
+        today.diff(habit.dates[habit.dates.length - 1], 'day'))
     );
   };
 

--- a/client/src/components/Habits/HabitsView.js
+++ b/client/src/components/Habits/HabitsView.js
@@ -41,7 +41,10 @@ const HabitsView = () => {
   const { habits } = useSelector((state) => state.habitReducer);
   const dispatch = useDispatch();
 
-  const handleOpen = () => setOpen(!open);
+  const handleOpen = () => {
+    setDays(new Array(7).fill(true));
+    setOpen(!open);
+  }
 
   useEffect(() => {
     if (user.isLoggedIn) {
@@ -118,40 +121,42 @@ const HabitsView = () => {
         <CardBody className="flex-1 py-0 max-h-[10rem] overflow-y-auto scrollbar-none scrollbar-thumb-rounded-full scrollbar-thumb-blue-gray-100/50">
           <List className="w-full">
             {habits.map((habit) => {
-              return (
-                <ListItem key={habit._id} className="group p-0">
-                  <label
-                    htmlFor={habit._id}
-                    className="px-3 py-2 flex items-center w-full cursor-pointer"
-                  >
-                    <ListItemPrefix className="mr-3">
-                      <Checkbox
-                        id={habit._id}
-                        ripple={false}
-                        color="indigo"
-                        className="border-indigo-300/50 bg-indigo-50 transition-all hover:scale-105 hover:before:opacity-0"
-                        containerProps={{
-                          className: "p-0",
-                        }}
-                        onClick={() => toggleHabit(habit._id)}
-                        defaultChecked={isTicked(habit)}
-                      />
-                    </ListItemPrefix>
-                    <Typography color="blue-gray" className="font-medium">
-                      {habit.name}
-                    </Typography>
-                    <IconButton
-                      color="blue-gray"
-                      variant="text"
-                      size="sm"
-                      className="hidden group-hover:block rounded-full ml-auto"
-                      onClick={() => deleteHabit(habit._id)}
+              if (habit.days[dayjs().day()]) {
+                return (
+                  <ListItem key={habit._id} className="group p-0">
+                    <label
+                      htmlFor={habit._id}
+                      className="px-3 py-2 flex items-center w-full cursor-pointer"
                     >
-                      ✕
-                    </IconButton>
-                  </label>
-                </ListItem>
-              );
+                      <ListItemPrefix className="mr-3">
+                        <Checkbox
+                          id={habit._id}
+                          ripple={false}
+                          color="indigo"
+                          className="border-indigo-300/50 bg-indigo-50 transition-all hover:scale-105 hover:before:opacity-0"
+                          containerProps={{
+                            className: "p-0",
+                          }}
+                          onClick={() => toggleHabit(habit._id)}
+                          defaultChecked={isTicked(habit)}
+                        />
+                      </ListItemPrefix>
+                      <Typography color="blue-gray" className="font-medium">
+                        {habit.name}
+                      </Typography>
+                      <IconButton
+                        color="blue-gray"
+                        variant="text"
+                        size="sm"
+                        className="hidden group-hover:block rounded-full ml-auto"
+                        onClick={() => deleteHabit(habit._id)}
+                      >
+                        ✕
+                      </IconButton>
+                    </label>
+                  </ListItem>
+                );
+              }
             })}
           </List>
         </CardBody>

--- a/server/controllers/habit.controller.js
+++ b/server/controllers/habit.controller.js
@@ -1,5 +1,7 @@
 const Module = require('../models/habit.model')
 const dayjs = require('dayjs')
+let utc = require('dayjs/plugin/utc')
+dayjs.extend(utc)
 
 const getHabits = async (req, res) => {
     const habits = await Module.find({userID: req.params.userID})
@@ -27,8 +29,8 @@ const toggleHabitDate = async (req, res) => {
     let day = date.getDate()
     let month = date.getMonth()
     let year = date.getFullYear()
-    date = new Date(year, month, day)
-    let today = dayjs(date)
+    date = Date.UTC(year, month, day)
+    let today = dayjs(date).utc()
 
     if (habit.dates.length > 0 && today.diff(habit.dates[habit.dates.length - 1])) {
         habit.dates.push(today)

--- a/server/controllers/habit.controller.js
+++ b/server/controllers/habit.controller.js
@@ -25,10 +25,14 @@ const addHabit = async (req, res) => {
 const toggleHabitDate = async (req, res) => {
     const habit = await Module.findOne({_id: req.params.habitID}).exec()
 
-    let date = new Date()
-    let day = date.getDate()
-    let month = date.getMonth()
-    let year = date.getFullYear()
+    // let date = new Date()
+    // let day = date.getDate()
+    // let month = date.getMonth()
+    // let year = date.getFullYear()
+    let date = dayjs().utc()
+    let day = date.get("date")
+    let month = date.get("month")
+    let year = date.get("year")
     date = Date.UTC(year, month, day)
     let today = dayjs(date).utc()
 

--- a/server/controllers/habit.controller.js
+++ b/server/controllers/habit.controller.js
@@ -25,16 +25,6 @@ const addHabit = async (req, res) => {
 const toggleHabitDate = async (req, res) => {
     const habit = await Module.findOne({_id: req.params.habitID}).exec()
 
-    // let date = new Date()
-    // let day = date.getDate()
-    // let month = date.getMonth()
-    // let year = date.getFullYear()
-    // let date = dayjs().utc()
-    // let day = date.get("date")
-    // let month = date.get("month")
-    // let year = date.get("year")
-    // date = Date.UTC(year, month, day)
-    // let today = dayjs(date).utc()
     let today = dayjs().utc()
     console.log(today)
 

--- a/server/controllers/habit.controller.js
+++ b/server/controllers/habit.controller.js
@@ -29,14 +29,16 @@ const toggleHabitDate = async (req, res) => {
     // let day = date.getDate()
     // let month = date.getMonth()
     // let year = date.getFullYear()
-    let date = dayjs().utc()
-    let day = date.get("date")
-    let month = date.get("month")
-    let year = date.get("year")
-    date = Date.UTC(year, month, day)
-    let today = dayjs(date).utc()
+    // let date = dayjs().utc()
+    // let day = date.get("date")
+    // let month = date.get("month")
+    // let year = date.get("year")
+    // date = Date.UTC(year, month, day)
+    // let today = dayjs(date).utc()
+    let today = dayjs().utc()
+    console.log(today)
 
-    if (habit.dates.length > 0 && today.diff(habit.dates[habit.dates.length - 1])) {
+    if (habit.dates.length > 0 && today.diff(habit.dates[habit.dates.length - 1], 'day')) {
         habit.dates.push(today)
         await habit.save()
     } else if (habit.dates.length === 0) {


### PR DESCRIPTION
There are only two changes:

1. Add `setDays(new Array(7).fill(true));` to `handleOpen` - Done so that days state (the state that keeps track of which days of the week the habit corresponds to) is reset every time the modal is open or closed; it doesn't matter if the user exits via esc or clicking away, because once the user opens the modal again, `handleOpen` is called. Previously, the days state was not reset every time after a habit was cancelled or added, even though the ui of the days looked to be reset. This caused the bug.

2. Only display habits where `(habit.days[dayjs().day()])` is true - `dayjs().day()` generates a number from 0 - 6 that indicates the day of the week, where 0 is Sunday, and 6 is Saturday (which corresponds with the dates array). Thus, we can check the corresponding index of `habit.days` to verify if we set that date to be true or not before displaying.

Please try this on your own and verify.